### PR TITLE
[SITE] Stitch 기반 랜딩 전면 리뉴얼 및 한/영 전환 기능 추가

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -48,6 +48,25 @@ a {
   text-decoration: none;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-noto-sans-kr, var(--font-display));
+  word-break: keep-all;
+}
+
+p,
+li,
+a,
+button,
+input,
+label {
+  word-break: keep-all;
+}
+
 // Dark mode color-scheme
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme='light']) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,26 @@
 import type { Metadata } from 'next';
+import { Inter, Plus_Jakarta_Sans, Noto_Sans_KR } from 'next/font/google';
+import { LocaleProvider } from '@/contexts/LocaleContext';
 import './globals.scss';
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap',
+});
+
+const plusJakartaSans = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  variable: '--font-plus-jakarta-sans',
+  display: 'swap',
+});
+
+const notoSansKR = Noto_Sans_KR({
+  subsets: ['latin'],
+  variable: '--font-noto-sans-kr',
+  display: 'swap',
+  weight: ['400', '500', '600', '700'],
+});
 
 const siteDescription =
   'Drop documents and images onto an infinite canvas. Organize ideas spatially, connect them visually, and collaborate in real time.';
@@ -11,29 +32,17 @@ export const metadata: Metadata = {
     template: '%s | CastCanvas Lab',
   },
   description: siteDescription,
-  alternates: {
-    canonical: '/',
-  },
+  alternates: { canonical: '/' },
   verification: process.env.GOOGLE_SITE_VERIFICATION
-    ? {
-        google: process.env.GOOGLE_SITE_VERIFICATION,
-      }
+    ? { google: process.env.GOOGLE_SITE_VERIFICATION }
     : undefined,
   openGraph: {
     title: 'CastCanvas Lab — Spatial Research Workspace',
     description: siteDescription,
     url: 'https://castcanvaslab.com',
     siteName: 'CastCanvas Lab',
-    locale: 'ko_KR',
     type: 'website',
-    images: [
-      {
-        url: '/og-image.svg',
-        width: 1200,
-        height: 630,
-        alt: 'CastCanvas Lab spatial research workspace preview',
-      },
-    ],
+    images: [{ url: '/og-image.svg', width: 1200, height: 630, alt: 'CastCanvas Lab preview' }],
   },
   twitter: {
     card: 'summary_large_image',
@@ -43,14 +52,15 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ko">
-      <body>{children}</body>
+    <html
+      lang="en"
+      className={`${inter.variable} ${plusJakartaSans.variable} ${notoSansKR.variable}`}
+    >
+      <body>
+        <LocaleProvider>{children}</LocaleProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/Cta/Cta.module.scss
+++ b/src/components/Cta/Cta.module.scss
@@ -2,48 +2,101 @@
 
 .section {
   @include section;
+  background: var(--color-bg-app);
 }
 
 .inner {
   @include container;
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  justify-content: center;
+}
+
+.content {
+  max-width: 520px;
+  width: 100%;
   text-align: center;
-  padding-block: var(--space-20);
-  border-radius: var(--radius-2xl);
-  background: var(--palette-primary-50);
-
-  @media (prefers-color-scheme: dark) {
-    :root:not([data-theme='light']) & {
-      background: rgba(99, 102, 241, 0.08);
-    }
-  }
-
-  [data-theme='dark'] & {
-    background: rgba(99, 102, 241, 0.08);
-  }
 }
 
 .title {
-  font-size: var(--font-size-4xl);
+  margin: 0 0 var(--space-4);
+  font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-tight);
+  line-height: var(--line-height-snug);
   letter-spacing: var(--letter-spacing-tight);
-  color: var(--color-interactive-primary);
+  color: var(--color-text-primary);
 
-  @include md {
-    font-size: var(--font-size-5xl);
+  @include lg {
+    font-size: var(--font-size-4xl);
   }
 }
 
 .subtitle {
-  margin-top: var(--space-5);
-  font-size: var(--font-size-lg);
-  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-8);
+  font-size: var(--font-size-xl);
   line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
+}
 
-  @include md {
-    font-size: var(--font-size-xl);
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+
+  @include sm {
+    flex-direction: row;
   }
+}
+
+.input {
+  flex: 1;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-md);
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+
+  &::placeholder {
+    color: var(--color-text-tertiary);
+  }
+
+  &:focus {
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+  }
+}
+
+.button {
+  padding: var(--space-3) var(--space-6);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-on-primary);
+  background: var(--color-interactive-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--transition-fast);
+
+  &:hover {
+    background: var(--color-interactive-primary-hover);
+  }
+
+  &:active {
+    background: var(--color-interactive-primary-active);
+  }
+}
+
+.note {
+  margin: var(--space-4) 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+}
+
+.srOnly {
+  @include visually-hidden;
 }

--- a/src/components/Cta/Cta.tsx
+++ b/src/components/Cta/Cta.tsx
@@ -1,16 +1,52 @@
+'use client';
+
+import { useLocale } from '@/contexts/LocaleContext';
 import styles from './Cta.module.scss';
 
+const copy = {
+  en: {
+    title: 'Be the first to try CastCanvas Lab.',
+    subtitle: "We're building in public. Sign up to get early access when we launch.",
+    placeholder: 'you@example.com',
+    button: 'Notify me',
+    note: 'No spam. Only progress updates.',
+  },
+  ko: {
+    title: '가장 먼저 써보고 싶으신가요?',
+    subtitle: '지금 만들고 있습니다. 출시 소식을 이메일로 받아보세요.',
+    placeholder: 'your@email.com',
+    button: '알림 신청',
+    note: '스팸은 없습니다. 출시 소식만 전해드립니다.',
+  },
+};
+
 export default function Cta() {
+  const { locale } = useLocale();
+  const t = copy[locale];
+
   return (
     <section id="cta" className={styles.section}>
       <div className={styles.inner}>
-        <h2 className={styles.title}>Coming Soon</h2>
-        <p className={styles.subtitle}>
-          CastCanvas Lab은 현재 개발 중입니다.
-          <br />
-          공간 위에서 리서치하는 새로운 경험을 곧 만나보세요.
-        </p>
-        {/* TODO: 얼리 액세스 이메일 폼 추가 */}
+        <div className={styles.content}>
+          <h2 className={styles.title}>{t.title}</h2>
+          <p className={styles.subtitle}>{t.subtitle}</p>
+          <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
+            <label htmlFor="cta-email" className={styles.srOnly}>
+              Email address
+            </label>
+            <input
+              id="cta-email"
+              type="email"
+              placeholder={t.placeholder}
+              className={styles.input}
+              autoComplete="email"
+            />
+            <button type="submit" className={styles.button}>
+              {t.button}
+            </button>
+          </form>
+          <p className={styles.note}>{t.note}</p>
+        </div>
       </div>
     </section>
   );

--- a/src/components/Features/Features.module.scss
+++ b/src/components/Features/Features.module.scss
@@ -2,71 +2,97 @@
 
 .section {
   @include section;
+  background: var(--color-bg-app);
 }
 
 .inner {
   @include container;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
+  gap: var(--space-12);
+}
+
+.heading {
+  max-width: 56ch;
 }
 
 .title {
+  margin: 0 0 var(--space-4);
   font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
   line-height: var(--line-height-snug);
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
 
-  @include md {
+  @include lg {
     font-size: var(--font-size-4xl);
   }
 }
 
 .subtitle {
-  margin-top: var(--space-4);
-  font-size: var(--font-size-lg);
-  color: var(--color-text-secondary);
+  margin: 0;
+  font-size: var(--font-size-xl);
   line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
 }
 
 .grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--space-6);
-  margin-top: var(--space-12);
-  width: 100%;
+  gap: var(--space-4);
 
-  @include sm {
+  @include md {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @include lg {
+  @include xl {
     grid-template-columns: repeat(4, 1fr);
   }
 }
 
 .card {
-  @include surface;
-  padding: var(--space-8) var(--space-6);
-  text-align: left;
-  transition: box-shadow var(--transition-normal);
+  padding: var(--space-6);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  transition:
+    box-shadow var(--transition-normal),
+    border-color var(--transition-normal);
 
   &:hover {
-    box-shadow: var(--shadow-lg);
+    box-shadow: var(--shadow-md);
+    border-color: var(--color-border-strong);
+  }
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  margin-bottom: var(--space-4);
+  background: var(--palette-primary-50);
+  border-radius: var(--radius-md);
+  color: var(--color-interactive-primary);
+
+  [data-theme='dark'] & {
+    background: rgba(99, 102, 241, 0.12);
   }
 }
 
 .cardTitle {
-  font-size: var(--font-size-xl);
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
+  line-height: var(--line-height-snug);
 }
 
 .cardDesc {
-  margin-top: var(--space-3);
+  margin: 0;
   font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
-  line-height: var(--line-height-normal);
 }

--- a/src/components/Features/Features.tsx
+++ b/src/components/Features/Features.tsx
@@ -1,37 +1,133 @@
+'use client';
+
+import { useLocale } from '@/contexts/LocaleContext';
 import styles from './Features.module.scss';
 
-const features = [
-  {
-    title: 'Infinite Canvas',
-    description: '무한히 넓은 캔버스 위에서 자유롭게 팬하고 줌하며 리서치 자료를 펼쳐보세요.',
-  },
-  {
-    title: 'Document & Image',
-    description: 'PDF 문서와 이미지를 드래그 앤 드롭으로 캔버스에 바로 배치할 수 있습니다.',
-  },
-  {
-    title: 'Nodes & Edges',
-    description: '노트를 만들고, 노드 사이를 연결선으로 이어 아이디어의 관계를 시각화하세요.',
-  },
-  {
-    title: 'Real-time Collaboration',
-    description: '같은 워크스페이스에서 팀원과 실시간으로 함께 편집하고 커서를 공유합니다.',
-  },
+const icons = [
+  <svg key="0" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M3 3H10V10H3V3Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    <path d="M14 3H21V10H14V3Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    <path d="M3 14H10V21H3V14Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    <path
+      d="M17.5 14V21M14 17.5H21"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>,
+  <svg key="1" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle cx="5" cy="12" r="2.5" stroke="currentColor" strokeWidth="1.5" />
+    <circle cx="19" cy="6" r="2.5" stroke="currentColor" strokeWidth="1.5" />
+    <circle cx="19" cy="18" r="2.5" stroke="currentColor" strokeWidth="1.5" />
+    <path
+      d="M7.5 12H12M14 7.5L12 12M14 16.5L12 12"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>,
+  <svg key="2" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle cx="9" cy="7" r="3" stroke="currentColor" strokeWidth="1.5" />
+    <circle cx="17" cy="10" r="2.5" stroke="currentColor" strokeWidth="1.5" />
+    <path
+      d="M3 19C3 16.2 5.7 14 9 14C10.2 14 11.3 14.3 12.2 14.9"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M14 19C14 17.3 15.3 16 17 16C18.7 16 20 17.3 20 19"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>,
+  <svg key="3" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V8L14 2Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+    <path d="M14 2V8H20" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    <path d="M8 13H16M8 17H13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>,
 ];
 
+const copy = {
+  en: {
+    title: 'Everything you need to think spatially.',
+    subtitle:
+      'Built for depth, designed for clarity. CastCanvas Lab turns your screen into an active cognitive environment.',
+    items: [
+      {
+        title: 'Infinite Canvas',
+        description:
+          'Place anything, anywhere. No grid, no limits. Pan and zoom freely across a workspace that grows with your research.',
+      },
+      {
+        title: 'Visual Connections',
+        description:
+          'Draw edges between nodes to map relationships. Turn a collection of documents into a connected knowledge graph.',
+      },
+      {
+        title: 'Real-time Collaboration',
+        description:
+          'Work together on the same canvas, live. See where your colleagues are focusing and co-create in real time.',
+      },
+      {
+        title: 'Documents & Images',
+        description:
+          'Drag and drop PDFs and images directly onto the canvas. View, annotate, and reference them without leaving your workspace.',
+      },
+    ],
+  },
+  ko: {
+    title: '리서치에 필요한 것, 한 곳에.',
+    subtitle:
+      '복잡한 자료도 캔버스 위에 펼쳐두면 구조가 보입니다. CastCanvas Lab은 생각의 흐름을 방해하지 않습니다.',
+    items: [
+      {
+        title: '무한 캔버스',
+        description:
+          '격자도, 페이지도 없습니다. 자료를 원하는 곳에 두고, 필요할 때 확대하거나 전체를 조망하세요.',
+      },
+      {
+        title: '시각적 연결',
+        description:
+          '자료 사이에 선을 그어 관계를 표시하세요. 흩어진 문서들이 하나의 지식 지도로 이어집니다.',
+      },
+      {
+        title: '실시간 협업',
+        description:
+          '같은 캔버스에서 팀원과 동시에 작업하세요. 서로 어디를 보고 있는지 바로 확인할 수 있습니다.',
+      },
+      {
+        title: '문서 & 이미지',
+        description:
+          'PDF와 이미지를 캔버스에 바로 올려두세요. 다른 탭을 열지 않고도 보고, 메모하고, 연결할 수 있습니다.',
+      },
+    ],
+  },
+};
+
 export default function Features() {
+  const { locale } = useLocale();
+  const t = copy[locale];
+
   return (
     <section id="features" className={styles.section}>
       <div className={styles.inner}>
-        <h2 className={styles.title}>Core Features</h2>
-        <p className={styles.subtitle}>
-          리서치에 필요한 핵심 기능을 하나의 캔버스 안에 담았습니다.
-        </p>
+        <div className={styles.heading}>
+          <h2 className={styles.title}>{t.title}</h2>
+          <p className={styles.subtitle}>{t.subtitle}</p>
+        </div>
         <div className={styles.grid}>
-          {features.map(({ title, description }) => (
-            <article key={title} className={styles.card}>
-              <h3 className={styles.cardTitle}>{title}</h3>
-              <p className={styles.cardDesc}>{description}</p>
+          {t.items.map((item, i) => (
+            <article key={i} className={styles.card}>
+              <span className={styles.icon}>{icons[i]}</span>
+              <h3 className={styles.cardTitle}>{item.title}</h3>
+              <p className={styles.cardDesc}>{item.description}</p>
             </article>
           ))}
         </div>

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -1,32 +1,59 @@
 @use '../../shared/styles/mixins' as *;
 
 .footer {
+  padding-block: var(--space-12);
+  background: var(--color-bg-sunken);
   border-top: 1px solid var(--color-border-subtle);
-  padding-block: var(--space-10);
 }
 
 .inner {
   @include container;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: var(--space-3);
-  text-align: center;
+  align-items: flex-start;
+  gap: var(--space-2);
 
   @include md {
     flex-direction: row;
+    align-items: center;
     justify-content: space-between;
   }
 }
 
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.logoMark {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  background: var(--color-interactive-primary);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
 .logo {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
   letter-spacing: var(--letter-spacing-tight);
 }
 
+.tagline {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+
+  @include md {
+    margin-inline: auto;
+  }
+}
+
 .copy {
+  margin: 0;
   font-size: var(--font-size-sm);
   color: var(--color-text-tertiary);
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,10 +1,25 @@
+'use client';
+
+import { useLocale } from '@/contexts/LocaleContext';
 import styles from './Footer.module.scss';
 
+const copy = {
+  en: { tagline: 'Spatial workspace for researchers.' },
+  ko: { tagline: '생각을 펼쳐두는 리서치 공간.' },
+};
+
 export default function Footer() {
+  const { locale } = useLocale();
+  const t = copy[locale];
+
   return (
     <footer className={styles.footer}>
       <div className={styles.inner}>
-        <span className={styles.logo}>CastCanvas Lab</span>
+        <div className={styles.brand}>
+          <span className={styles.logoMark} aria-hidden="true" />
+          <span className={styles.logo}>CastCanvas Lab</span>
+        </div>
+        <p className={styles.tagline}>{t.tagline}</p>
         <p className={styles.copy}>
           &copy; {new Date().getFullYear()} CastCanvas Lab. All rights reserved.
         </p>

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -1,45 +1,57 @@
 @use '../../shared/styles/mixins' as *;
 
 .header {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 0;
-  right: 0;
   z-index: var(--z-sticky);
   height: var(--header-height);
-  background: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(12px);
+  background: var(--color-bg-app);
   border-bottom: 1px solid var(--color-border-subtle);
+  transition: box-shadow var(--transition-normal);
+}
 
-  @media (prefers-color-scheme: dark) {
-    :root:not([data-theme='light']) & {
-      background: rgba(8, 11, 20, 0.85);
-    }
-  }
-
-  [data-theme='dark'] & {
-    background: rgba(8, 11, 20, 0.85);
-  }
+.scrolled {
+  box-shadow: var(--shadow-sm);
 }
 
 .inner {
   @include container;
+  height: 100%;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  height: 100%;
+  gap: var(--space-8);
 }
 
 .logo {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
   letter-spacing: var(--letter-spacing-tight);
+  text-decoration: none;
+  flex-shrink: 0;
+
+  &:hover {
+    color: var(--color-interactive-primary);
+  }
+}
+
+.logoMark {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background: var(--color-interactive-primary);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
 }
 
 .nav {
   display: none;
-  gap: var(--space-8);
+  align-items: center;
+  gap: var(--space-6);
+  margin-left: auto;
 
   @include md {
     display: flex;
@@ -49,6 +61,7 @@
     font-size: var(--font-size-md);
     font-weight: var(--font-weight-medium);
     color: var(--color-text-secondary);
+    text-decoration: none;
     transition: color var(--transition-fast);
 
     &:hover {
@@ -57,19 +70,35 @@
   }
 }
 
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
+
+  @include md {
+    margin-left: 0;
+  }
+}
+
 .cta {
   display: inline-flex;
   align-items: center;
-  height: 36px;
-  padding: 0 var(--space-5);
-  border-radius: var(--radius-full);
-  background: var(--color-interactive-primary);
-  color: var(--color-text-on-primary);
+  padding: var(--space-2) var(--space-4);
   font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  transition: background var(--transition-fast);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    background var(--transition-fast);
 
   &:hover {
-    background: var(--color-interactive-primary-hover);
+    color: var(--color-text-primary);
+    border-color: var(--color-border-strong);
+    background: var(--color-bg-sunken);
   }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,22 +1,46 @@
+'use client';
+
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useLocale } from '@/contexts/LocaleContext';
+import LanguageSwitcher from '@/components/LanguageSwitcher/LanguageSwitcher';
 import styles from './Header.module.scss';
 
+const copy = {
+  en: { features: 'Features', howItWorks: 'How it works', cta: 'Coming Soon' },
+  ko: { features: '기능', howItWorks: '사용법', cta: '출시 예정' },
+};
+
 export default function Header() {
+  const { locale } = useLocale();
+  const t = copy[locale];
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 16);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
   return (
-    <header className={styles.header}>
+    <header className={`${styles.header} ${scrolled ? styles.scrolled : ''}`}>
       <div className={styles.inner}>
         <Link href="/" className={styles.logo}>
+          <span className={styles.logoMark} aria-hidden="true" />
           CastCanvas Lab
         </Link>
 
-        <nav className={styles.nav}>
-          <a href="#features">Features</a>
-          <a href="#how-it-works">How it works</a>
+        <nav className={styles.nav} aria-label="Main navigation">
+          <a href="#features">{t.features}</a>
+          <a href="#how-it-works">{t.howItWorks}</a>
         </nav>
 
-        <a href="#cta" className={styles.cta}>
-          Get Started
-        </a>
+        <div className={styles.actions}>
+          <LanguageSwitcher />
+          <a href="#cta" className={styles.cta}>
+            {t.cta}
+          </a>
+        </div>
       </div>
     </header>
   );

--- a/src/components/Hero/Hero.module.scss
+++ b/src/components/Hero/Hero.module.scss
@@ -1,58 +1,63 @@
 @use '../../shared/styles/mixins' as *;
 
 .hero {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 100dvh;
-  padding-top: var(--header-height);
+  padding-block: var(--space-20) var(--space-16);
+  background: var(--color-bg-app);
+  overflow: hidden;
+
+  @include lg {
+    padding-block: var(--space-24) var(--space-20);
+  }
 }
 
 .inner {
   @include container;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
+  gap: var(--space-16);
+
+  @include lg {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-16);
+  }
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
 }
 
 .badge {
   display: inline-block;
-  padding: var(--space-1) var(--space-4);
-  border-radius: var(--radius-full);
+  margin-bottom: var(--space-5);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-caps);
+  text-transform: uppercase;
+  color: var(--color-interactive-primary);
   background: var(--palette-primary-50);
-  color: var(--palette-primary-600);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: var(--letter-spacing-wide);
-  margin-bottom: var(--space-6);
-
-  @media (prefers-color-scheme: dark) {
-    :root:not([data-theme='light']) & {
-      background: rgba(99, 102, 241, 0.12);
-      color: var(--palette-primary-300);
-    }
-  }
+  border: 1px solid var(--palette-primary-200);
+  border-radius: var(--radius-full);
 
   [data-theme='dark'] & {
     background: rgba(99, 102, 241, 0.12);
+    border-color: rgba(99, 102, 241, 0.3);
     color: var(--palette-primary-300);
   }
 }
 
 .title {
+  margin: 0 0 var(--space-5);
   font-size: var(--font-size-4xl);
   font-weight: var(--font-weight-bold);
   line-height: var(--line-height-tight);
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
 
-  @include md {
-    font-size: var(--font-size-5xl);
-  }
-
   @include lg {
-    font-size: var(--font-size-6xl);
+    font-size: var(--font-size-5xl);
   }
 }
 
@@ -61,64 +66,90 @@
 }
 
 .subtitle {
-  margin-top: var(--space-6);
-  font-size: var(--font-size-lg);
+  margin: 0 0 var(--space-8);
+  font-size: var(--font-size-xl);
   line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
-  max-width: 560px;
-
-  @include md {
-    font-size: var(--font-size-xl);
-  }
+  max-width: 48ch;
 }
 
 .brDesktop {
   display: none;
 
-  @include md {
+  @include lg {
     display: inline;
   }
 }
 
 .actions {
   display: flex;
-  gap: var(--space-4);
-  margin-top: var(--space-10);
+  flex-wrap: wrap;
+  gap: var(--space-3);
 }
 
 .primary {
   display: inline-flex;
   align-items: center;
-  height: 48px;
-  padding: 0 var(--space-8);
-  border-radius: var(--radius-full);
-  background: var(--color-interactive-primary);
-  color: var(--color-text-on-primary);
-  font-size: var(--font-size-lg);
+  padding: var(--space-3) var(--space-6);
+  font-size: var(--font-size-md);
   font-weight: var(--font-weight-semibold);
-  transition: background var(--transition-fast);
+  color: var(--color-text-on-primary);
+  background: var(--color-interactive-primary);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  opacity: 0.75;
+  cursor: default;
+  transition: opacity var(--transition-fast);
 
   &:hover {
-    background: var(--color-interactive-primary-hover);
+    opacity: 0.85;
   }
 }
 
 .secondary {
   display: inline-flex;
   align-items: center;
-  height: 48px;
-  padding: 0 var(--space-8);
-  border-radius: var(--radius-full);
-  border: 1px solid var(--color-border-default);
+  padding: var(--space-3) var(--space-6);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text-primary);
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
+  background: transparent;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  text-decoration: none;
   transition:
-    background var(--transition-fast),
-    border-color var(--transition-fast);
+    border-color var(--transition-fast),
+    background var(--transition-fast);
 
   &:hover {
-    background: var(--color-interactive-secondary);
     border-color: var(--color-border-strong);
+    background: var(--color-bg-sunken);
   }
+}
+
+.visual {
+  flex: 1;
+  min-width: 0;
+  max-width: 560px;
+  width: 100%;
+  margin-inline: auto;
+
+  @include lg {
+    margin-inline: 0;
+  }
+}
+
+.canvas {
+  background: var(--color-bg-sunken);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-xl);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.canvasSvg {
+  width: 100%;
+  height: auto;
+  display: block;
 }

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,29 +1,264 @@
+'use client';
+
+import { useLocale } from '@/contexts/LocaleContext';
 import styles from './Hero.module.scss';
 
+const copy = {
+  en: {
+    badge: 'Spatial Research Workspace',
+    title: 'A workspace where your',
+    titleAccent: 'research takes shape.',
+    subtitle:
+      'Place documents, images, and notes on an infinite canvas. Connect them visually. Think spatially.',
+    primaryCta: 'Coming Soon',
+    secondaryCta: 'See how it works',
+  },
+  ko: {
+    badge: '공간형 리서치 워크스페이스',
+    title: '생각의 흐름을 그대로',
+    titleAccent: '펼쳐두는 공간.',
+    subtitle:
+      '문서, 이미지, 메모를 하나의 캔버스에 올려두고 연결하세요. 리서치가 눈앞에 펼쳐집니다.',
+    primaryCta: '출시 예정',
+    secondaryCta: '어떻게 쓰나요?',
+  },
+};
+
 export default function Hero() {
+  const { locale } = useLocale();
+  const t = copy[locale];
+
   return (
     <section className={styles.hero}>
       <div className={styles.inner}>
-        <p className={styles.badge}>Spatial Research Workspace</p>
-        <h1 className={styles.title}>
-          아이디어를 공간 위에
-          <br />
-          <span className={styles.accent}>배치하고, 연결하세요</span>
-        </h1>
-        <p className={styles.subtitle}>
-          문서와 이미지를 무한 캔버스 위에 자유롭게 올려놓고,
-          <br className={styles.brDesktop} />
-          시각적으로 정리하고, 실시간으로 함께 작업하세요.
-        </p>
-        <div className={styles.actions}>
-          <a href="#cta" className={styles.primary}>
-            Coming Soon
-          </a>
-          <a href="#features" className={styles.secondary}>
-            기능 살펴보기
-          </a>
+        <div className={styles.content}>
+          <p className={styles.badge}>{t.badge}</p>
+          <h1 className={styles.title}>
+            {t.title}
+            <br />
+            <span className={styles.accent}>{t.titleAccent}</span>
+          </h1>
+          <p className={styles.subtitle}>{t.subtitle}</p>
+          <div className={styles.actions}>
+            <a href="#cta" className={styles.primary}>
+              {t.primaryCta}
+            </a>
+            <a href="#how-it-works" className={styles.secondary}>
+              {t.secondaryCta}
+            </a>
+          </div>
+        </div>
+
+        <div className={styles.visual} aria-hidden="true">
+          <CanvasPreview />
         </div>
       </div>
     </section>
+  );
+}
+
+function CanvasPreview() {
+  return (
+    <div className={styles.canvas}>
+      <svg
+        viewBox="0 0 560 380"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className={styles.canvasSvg}
+        aria-hidden="true"
+      >
+        {Array.from({ length: 12 }).map((_, row) =>
+          Array.from({ length: 18 }).map((_, col) => (
+            <circle
+              key={`${row}-${col}`}
+              cx={col * 32 + 16}
+              cy={row * 32 + 16}
+              r="1.5"
+              fill="var(--palette-neutral-300)"
+              opacity="0.4"
+            />
+          )),
+        )}
+        <line
+          x1="140"
+          y1="100"
+          x2="280"
+          y2="160"
+          stroke="var(--palette-primary-400)"
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
+          opacity="0.6"
+        />
+        <line
+          x1="280"
+          y1="160"
+          x2="400"
+          y2="100"
+          stroke="var(--palette-primary-400)"
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
+          opacity="0.6"
+        />
+        <line
+          x1="280"
+          y1="160"
+          x2="280"
+          y2="270"
+          stroke="var(--palette-primary-400)"
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
+          opacity="0.6"
+        />
+        <line
+          x1="140"
+          y1="100"
+          x2="80"
+          y2="220"
+          stroke="var(--palette-neutral-300)"
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
+          opacity="0.4"
+        />
+        <rect
+          x="88"
+          y="62"
+          width="104"
+          height="76"
+          rx="8"
+          fill="var(--color-bg-surface)"
+          stroke="var(--color-border-default)"
+          strokeWidth="1"
+        />
+        <rect x="100" y="76" width="60" height="6" rx="3" fill="var(--palette-neutral-200)" />
+        <rect x="100" y="88" width="80" height="4" rx="2" fill="var(--palette-neutral-100)" />
+        <rect x="100" y="98" width="72" height="4" rx="2" fill="var(--palette-neutral-100)" />
+        <rect x="100" y="108" width="56" height="4" rx="2" fill="var(--palette-neutral-100)" />
+        <rect x="100" y="118" width="64" height="4" rx="2" fill="var(--palette-neutral-100)" />
+        <rect x="88" y="62" width="104" height="14" rx="8" fill="var(--palette-primary-100)" />
+        <rect x="88" y="68" width="104" height="8" fill="var(--palette-primary-100)" />
+        <text
+          x="100"
+          y="73"
+          fontSize="7"
+          fill="var(--palette-primary-700)"
+          fontFamily="Inter, sans-serif"
+          fontWeight="500"
+        >
+          PDF Document
+        </text>
+        <rect
+          x="328"
+          y="62"
+          width="104"
+          height="76"
+          rx="8"
+          fill="var(--color-bg-surface)"
+          stroke="var(--color-border-default)"
+          strokeWidth="1"
+        />
+        <rect x="328" y="62" width="104" height="44" rx="8" fill="var(--palette-neutral-100)" />
+        <rect x="328" y="88" width="104" height="18" fill="var(--palette-neutral-100)" />
+        <circle cx="380" cy="82" r="12" fill="var(--palette-neutral-200)" />
+        <polyline
+          points="340,106 360,88 376,98 392,80 420,106"
+          stroke="var(--palette-neutral-300)"
+          strokeWidth="1.5"
+          fill="none"
+        />
+        <text
+          x="340"
+          y="122"
+          fontSize="7"
+          fill="var(--color-text-secondary)"
+          fontFamily="Inter, sans-serif"
+        >
+          Reference Image
+        </text>
+        <text
+          x="340"
+          y="132"
+          fontSize="6"
+          fill="var(--color-text-tertiary)"
+          fontFamily="Inter, sans-serif"
+        >
+          canvas-sketch.png
+        </text>
+        <rect
+          x="228"
+          y="130"
+          width="104"
+          height="72"
+          rx="8"
+          fill="var(--palette-primary-50)"
+          stroke="var(--palette-primary-200)"
+          strokeWidth="1"
+        />
+        <rect x="240" y="144" width="48" height="5" rx="2.5" fill="var(--palette-primary-400)" />
+        <rect x="240" y="155" width="80" height="4" rx="2" fill="var(--palette-primary-200)" />
+        <rect x="240" y="165" width="72" height="4" rx="2" fill="var(--palette-primary-200)" />
+        <rect x="240" y="175" width="60" height="4" rx="2" fill="var(--palette-primary-200)" />
+        <text
+          x="240"
+          y="143"
+          fontSize="7"
+          fill="var(--palette-primary-700)"
+          fontFamily="Inter, sans-serif"
+          fontWeight="600"
+        >
+          Core Hypothesis
+        </text>
+        <rect
+          x="228"
+          y="240"
+          width="104"
+          height="64"
+          rx="8"
+          fill="var(--color-bg-surface)"
+          stroke="var(--color-border-default)"
+          strokeWidth="1"
+        />
+        <rect x="240" y="254" width="40" height="5" rx="2.5" fill="var(--palette-neutral-300)" />
+        <rect x="240" y="265" width="80" height="4" rx="2" fill="var(--palette-neutral-100)" />
+        <rect x="240" y="275" width="64" height="4" rx="2" fill="var(--palette-neutral-100)" />
+        <text
+          x="240"
+          y="253"
+          fontSize="7"
+          fill="var(--color-text-secondary)"
+          fontFamily="Inter, sans-serif"
+          fontWeight="500"
+        >
+          Research Note
+        </text>
+        <rect
+          x="36"
+          y="188"
+          width="88"
+          height="64"
+          rx="8"
+          fill="var(--color-bg-surface)"
+          stroke="var(--color-border-default)"
+          strokeWidth="1"
+        />
+        <rect x="48" y="202" width="36" height="5" rx="2.5" fill="var(--palette-neutral-300)" />
+        <rect x="48" y="213" width="64" height="4" rx="2" fill="var(--palette-neutral-100)" />
+        <rect x="48" y="223" width="52" height="4" rx="2" fill="var(--palette-neutral-100)" />
+        <text
+          x="48"
+          y="201"
+          fontSize="7"
+          fill="var(--color-text-secondary)"
+          fontFamily="Inter, sans-serif"
+          fontWeight="500"
+        >
+          Source
+        </text>
+        <circle cx="140" cy="100" r="4" fill="var(--palette-primary-500)" />
+        <circle cx="280" cy="160" r="4" fill="var(--palette-primary-500)" />
+        <circle cx="400" cy="100" r="4" fill="var(--palette-primary-500)" />
+        <circle cx="280" cy="270" r="4" fill="var(--palette-primary-400)" opacity="0.7" />
+        <circle cx="80" cy="220" r="4" fill="var(--palette-neutral-400)" opacity="0.6" />
+      </svg>
+    </div>
   );
 }

--- a/src/components/HowItWorks/HowItWorks.module.scss
+++ b/src/components/HowItWorks/HowItWorks.module.scss
@@ -3,42 +3,44 @@
 .section {
   @include section;
   background: var(--color-bg-sunken);
+  border-top: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .inner {
   @include container;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
+  gap: var(--space-12);
+}
+
+.heading {
+  max-width: 56ch;
 }
 
 .title {
+  margin: 0 0 var(--space-3);
   font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
   line-height: var(--line-height-snug);
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
 
-  @include md {
+  @include lg {
     font-size: var(--font-size-4xl);
   }
 }
 
 .subtitle {
-  margin-top: var(--space-4);
-  font-size: var(--font-size-lg);
+  margin: 0;
+  font-size: var(--font-size-xl);
   color: var(--color-text-secondary);
 }
 
 .steps {
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--space-8);
-  margin-top: var(--space-12);
-  width: 100%;
-  max-width: 900px;
-  counter-reset: step;
+  gap: var(--space-4);
 
   @include md {
     grid-template-columns: repeat(3, 1fr);
@@ -46,34 +48,58 @@
 }
 
 .step {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-3);
+  position: relative;
+  padding: var(--space-6);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+
+  @include md {
+    &:not(:last-child)::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      right: calc(-1 * var(--space-4) / 2 - 1px);
+      width: var(--space-4);
+      height: 1px;
+      background: var(--color-border-default);
+      transform: translateY(-50%);
+    }
+  }
 }
 
 .number {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 56px;
-  height: 56px;
-  border-radius: var(--radius-full);
-  background: var(--color-interactive-primary);
-  color: var(--color-text-on-primary);
-  font-size: var(--font-size-xl);
+  display: inline-block;
+  margin-bottom: var(--space-4);
+  font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
+  line-height: 1;
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--palette-primary-200);
+
+  [data-theme='dark'] & {
+    color: rgba(99, 102, 241, 0.25);
+  }
+}
+
+.stepContent {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
 }
 
 .stepTitle {
-  font-size: var(--font-size-2xl);
+  margin: 0;
+  font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
+  line-height: var(--line-height-snug);
 }
 
 .stepDesc {
+  margin: 0;
   font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
-  line-height: var(--line-height-normal);
-  max-width: 260px;
 }

--- a/src/components/HowItWorks/HowItWorks.tsx
+++ b/src/components/HowItWorks/HowItWorks.tsx
@@ -1,35 +1,77 @@
+'use client';
+
+import { useLocale } from '@/contexts/LocaleContext';
 import styles from './HowItWorks.module.scss';
 
-const steps = [
-  {
-    number: '01',
-    title: 'Drop',
-    description: 'PDF, 이미지를 캔버스 위에 드래그 앤 드롭하세요.',
+const copy = {
+  en: {
+    title: 'From scattered files to connected thinking.',
+    subtitle: 'Three steps to start working spatially.',
+    steps: [
+      {
+        number: '01',
+        title: 'Upload documents and images',
+        description:
+          'Drag and drop PDFs, research papers, and screen captures directly onto the workspace.',
+      },
+      {
+        number: '02',
+        title: 'Arrange them on your canvas',
+        description:
+          'Group related concepts spatially. Move items around to discover new patterns and hierarchies.',
+      },
+      {
+        number: '03',
+        title: 'Connect nodes to build your map',
+        description:
+          'Create visual links that persist. Build a research map that explains the relationships behind your data.',
+      },
+    ],
   },
-  {
-    number: '02',
-    title: 'Arrange',
-    description: '자료를 공간적으로 배치하고, 노트를 추가하세요.',
+  ko: {
+    title: '자료를 모으고, 펼치고, 연결하세요.',
+    subtitle: '세 단계면 충분합니다.',
+    steps: [
+      {
+        number: '01',
+        title: '자료 올리기',
+        description: 'PDF, 이미지, 스크린샷을 캔버스에 드래그해서 올려두세요.',
+      },
+      {
+        number: '02',
+        title: '원하는 대로 배치하기',
+        description: '관련 있는 것끼리 가까이 두고, 보면서 자유롭게 옮기세요.',
+      },
+      {
+        number: '03',
+        title: '연결해서 구조 만들기',
+        description: '자료 사이에 선을 그으면 리서치의 흐름이 한눈에 보입니다.',
+      },
+    ],
   },
-  {
-    number: '03',
-    title: 'Connect',
-    description: '노드를 연결해 아이디어의 흐름을 시각화하세요.',
-  },
-];
+};
 
 export default function HowItWorks() {
+  const { locale } = useLocale();
+  const t = copy[locale];
+
   return (
     <section id="how-it-works" className={styles.section}>
       <div className={styles.inner}>
-        <h2 className={styles.title}>How It Works</h2>
-        <p className={styles.subtitle}>세 단계로 시작하는 공간적 리서치</p>
+        <div className={styles.heading}>
+          <h2 className={styles.title}>{t.title}</h2>
+          <p className={styles.subtitle}>{t.subtitle}</p>
+        </div>
         <ol className={styles.steps}>
-          {steps.map(({ number, title, description }) => (
-            <li key={number} className={styles.step}>
-              <span className={styles.number}>{number}</span>
-              <h3 className={styles.stepTitle}>{title}</h3>
-              <p className={styles.stepDesc}>{description}</p>
+          {t.steps.map((step) => (
+            <li key={step.number} className={styles.step}>
+              <span className={styles.number} aria-hidden="true">
+                {step.number}
+              </span>
+              <div className={styles.stepContent}>
+                <h3 className={styles.stepTitle}>{step.title}</h3>
+                <p className={styles.stepDesc}>{step.description}</p>
+              </div>
             </li>
           ))}
         </ol>

--- a/src/components/LanguageSwitcher/LanguageSwitcher.module.scss
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.module.scss
@@ -1,0 +1,36 @@
+.switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-caps);
+  background: none;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast);
+
+  &:hover {
+    border-color: var(--color-border-strong);
+    background: var(--color-bg-sunken);
+  }
+}
+
+.active {
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
+}
+
+.inactive {
+  color: var(--color-text-tertiary);
+}
+
+.divider {
+  color: var(--color-border-default);
+  margin-inline: 1px;
+}

--- a/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useLocale } from '@/contexts/LocaleContext';
+import styles from './LanguageSwitcher.module.scss';
+
+export default function LanguageSwitcher() {
+  const { locale, toggle } = useLocale();
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className={styles.switcher}
+      aria-label={locale === 'en' ? '한국어로 전환' : 'Switch to English'}
+    >
+      <span className={locale === 'en' ? styles.active : styles.inactive}>EN</span>
+      <span className={styles.divider} aria-hidden="true">
+        /
+      </span>
+      <span className={locale === 'ko' ? styles.active : styles.inactive}>KO</span>
+    </button>
+  );
+}

--- a/src/components/Problem/Problem.module.scss
+++ b/src/components/Problem/Problem.module.scss
@@ -3,43 +3,45 @@
 .section {
   @include section;
   background: var(--color-bg-sunken);
+  border-top: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .inner {
   @include container;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
+  gap: var(--space-12);
+}
+
+.heading {
+  max-width: 56ch;
 }
 
 .title {
+  margin: 0 0 var(--space-4);
   font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
   line-height: var(--line-height-snug);
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
 
-  @include md {
+  @include lg {
     font-size: var(--font-size-4xl);
   }
 }
 
 .subtitle {
-  margin-top: var(--space-4);
-  font-size: var(--font-size-lg);
-  color: var(--color-text-secondary);
-  max-width: 560px;
+  margin: 0;
+  font-size: var(--font-size-xl);
   line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
 }
 
-.list {
+.grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--space-5);
-  margin-top: var(--space-12);
-  width: 100%;
-  max-width: 900px;
+  gap: var(--space-4);
 
   @include md {
     grid-template-columns: repeat(3, 1fr);
@@ -47,34 +49,40 @@
 }
 
 .card {
-  @include surface;
-  padding: var(--space-8) var(--space-6);
+  padding: var(--space-6);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.icon {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: var(--space-3);
-  text-align: center;
-}
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  margin-bottom: var(--space-4);
+  background: var(--palette-primary-50);
+  border-radius: var(--radius-md);
+  color: var(--color-interactive-primary);
 
-.tool {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-text-primary);
-}
-
-.issue {
-  font-size: var(--font-size-md);
-  color: var(--color-text-secondary);
-  line-height: var(--line-height-normal);
-}
-
-.conclusion {
-  margin-top: var(--space-12);
-  font-size: var(--font-size-xl);
-  color: var(--color-text-primary);
-  line-height: var(--line-height-relaxed);
-
-  strong {
-    color: var(--color-interactive-primary);
+  [data-theme='dark'] & {
+    background: rgba(99, 102, 241, 0.12);
   }
+}
+
+.cardTitle {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  line-height: var(--line-height-snug);
+}
+
+.cardDesc {
+  margin: 0;
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
 }

--- a/src/components/Problem/Problem.tsx
+++ b/src/components/Problem/Problem.tsx
@@ -1,40 +1,105 @@
+'use client';
+
+import { useLocale } from '@/contexts/LocaleContext';
 import styles from './Problem.module.scss';
 
-const problems = [
-  {
-    tool: 'Notion',
-    issue: '정보를 쌓기엔 좋지만, 공간적으로 펼쳐보기 어렵습니다.',
-  },
-  {
-    tool: 'Figma',
-    issue: '시각적이지만, 문서를 다루기엔 적합하지 않습니다.',
-  },
-  {
-    tool: 'Miro',
-    issue: '보드는 넓지만, 리서치 문서 중심의 워크플로우에는 부족합니다.',
-  },
+const icons = [
+  <svg key="0" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M3 7C3 5.9 3.9 5 5 5H19C20.1 5 21 5.9 21 7V17C21 18.1 20.1 19 19 19H5C3.9 19 3 18.1 3 17V7Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M3 9H21" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M9 5V9" stroke="currentColor" strokeWidth="1.5" />
+  </svg>,
+  <svg key="1" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <rect x="2" y="3" width="20" height="14" rx="2" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M8 3V17" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M2 8H8" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M2 12H8" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M8 21H16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M12 17V21" stroke="currentColor" strokeWidth="1.5" />
+  </svg>,
+  <svg key="2" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
+    <path
+      d="M12 3V12L16 16"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <circle cx="12" cy="12" r="2" fill="currentColor" />
+  </svg>,
 ];
 
+const copy = {
+  en: {
+    title: "Research doesn't fit in a list.",
+    subtitle:
+      'Existing tools each have their strengths — but none let you work with documents and images spatially, the way your thinking actually flows.',
+    items: [
+      {
+        title: 'Files scattered across folders',
+        description:
+          'Finding the right document means digging through nested directories and cryptic filenames.',
+      },
+      {
+        title: 'Context lost between tabs',
+        description:
+          'Linear document structures break the mental links between your findings and your sources.',
+      },
+      {
+        title: 'No way to see the whole picture',
+        description:
+          "Standard tools force a top-down view. Real research requires a bird's-eye perspective.",
+      },
+    ],
+  },
+  ko: {
+    title: '리서치는 목록으로 정리되지 않습니다.',
+    subtitle:
+      '기존 도구들은 저마다 잘하는 게 있지만, 자료를 펼쳐놓고 한눈에 보기엔 늘 부족했습니다.',
+    items: [
+      {
+        title: '파일은 폴더 어딘가에 묻혀 있고',
+        description: '찾으려면 폴더를 뒤지고, 탭을 열고, 또 다른 탭을 열어야 합니다.',
+      },
+      {
+        title: '탭을 닫으면 맥락도 사라지고',
+        description: '어디서 뭘 봤는지, 왜 저장했는지 — 나중에 다시 열면 기억이 나지 않습니다.',
+      },
+      {
+        title: '전체 그림이 머릿속에만 있고',
+        description: '자료는 여기저기 흩어져 있는데, 연결해서 볼 수 있는 도구가 없었습니다.',
+      },
+    ],
+  },
+};
+
 export default function Problem() {
+  const { locale } = useLocale();
+  const t = copy[locale];
+
   return (
     <section className={styles.section}>
       <div className={styles.inner}>
-        <h2 className={styles.title}>리서치 도구, 뭔가 부족하지 않았나요?</h2>
-        <p className={styles.subtitle}>
-          기존 도구들은 각자의 강점이 있지만, 문서와 이미지를 공간 위에서 자유롭게 다루기엔 한계가
-          있습니다.
-        </p>
-        <ul className={styles.list}>
-          {problems.map(({ tool, issue }) => (
-            <li key={tool} className={styles.card}>
-              <span className={styles.tool}>{tool}</span>
-              <p className={styles.issue}>{issue}</p>
+        <div className={styles.heading}>
+          <h2 className={styles.title}>{t.title}</h2>
+          <p className={styles.subtitle}>{t.subtitle}</p>
+        </div>
+        <ul className={styles.grid}>
+          {t.items.map((item, i) => (
+            <li key={i} className={styles.card}>
+              <span className={styles.icon}>{icons[i]}</span>
+              <h3 className={styles.cardTitle}>{item.title}</h3>
+              <p className={styles.cardDesc}>{item.description}</p>
             </li>
           ))}
         </ul>
-        <p className={styles.conclusion}>
-          CastCanvas Lab은 <strong>공간적 사고와 문서 중심 리서치</strong>를 하나로 연결합니다.
-        </p>
       </div>
     </section>
   );

--- a/src/contexts/LocaleContext.tsx
+++ b/src/contexts/LocaleContext.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback } from 'react';
+
+export type Locale = 'en' | 'ko';
+
+interface LocaleContextValue {
+  locale: Locale;
+  toggle: () => void;
+}
+
+const LocaleContext = createContext<LocaleContextValue>({
+  locale: 'en',
+  toggle: () => {},
+});
+
+const COOKIE_KEY = 'locale';
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+function readCookie(): Locale {
+  if (typeof document === 'undefined') return 'en';
+  const match = document.cookie.match(new RegExp(`(?:^|; )${COOKIE_KEY}=([^;]*)`));
+  const val = match ? decodeURIComponent(match[1]) : null;
+  return val === 'ko' ? 'ko' : 'en';
+}
+
+function writeCookie(locale: Locale) {
+  document.cookie = `${COOKIE_KEY}=${locale}; max-age=${COOKIE_MAX_AGE}; path=/; SameSite=Lax`;
+}
+
+export function LocaleProvider({ children }: { children: React.ReactNode }) {
+  const [locale, setLocale] = useState<Locale>(readCookie);
+
+  const toggle = useCallback(() => {
+    setLocale((prev) => {
+      const next: Locale = prev === 'en' ? 'ko' : 'en';
+      writeCookie(next);
+      return next;
+    });
+  }, []);
+
+  return <LocaleContext.Provider value={{ locale, toggle }}>{children}</LocaleContext.Provider>;
+}
+
+export function useLocale() {
+  return useContext(LocaleContext);
+}

--- a/src/shared/styles/_typography.scss
+++ b/src/shared/styles/_typography.scss
@@ -8,7 +8,12 @@
 :root {
   // Font families
   --font-sans:
-    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+    var(--font-inter, 'Inter'), -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+    Arial, sans-serif;
+  --font-display:
+    var(--font-plus-jakarta-sans, 'Plus Jakarta Sans'), -apple-system, BlinkMacSystemFont,
+    sans-serif;
+  --font-display-ko: var(--font-noto-sans-kr, 'Noto Sans KR'), 'Apple SD Gothic Neo', sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
 
   // Font sizes — app-aligned


### PR DESCRIPTION
## Summary

- Google Stitch MCP로 랜딩 디자인 초안을 생성하고, 브랜드 톤에 맞게 전체 컴포넌트를 재작성했습니다 (SITE 이슈 #4 / ORCH 에픽 #8)
- 쿠키 기반 `LocaleContext`로 URL 변경 없는 한/영 전환 기능을 구현했습니다
- 한국어 카피를 번역투 없이 자연스럽게 재작성하고, Noto Sans KR 폰트를 추가했습니다

## Changes

### 디자인 리뉴얼 (Stitch 기반)
- 브랜드 확정: Indigo `#4f46e5`, Plus Jakarta Sans (headline) + Inter (body), 8px radius
- `Hero` — 새 카피 + SVG 인라인 캔버스 프리뷰 (노드/엣지 시각화)
- `Problem` — pain point 3개 카드 (아이콘 포함)
- `Features` — 핵심 기능 4개 카드 (아이콘 포함, hover 인터랙션)
- `HowItWorks` — 3-step 흐름 재편
- `CTA` — 이메일 입력 + 알림 신청 버튼
- `Header` — 스크롤 감지 border, 로고마크

### 한/영 전환
- `LocaleContext` — 쿠키 기반 locale 상태 관리 (새로고침/재방문 유지)
- `LanguageSwitcher` — 헤더 EN/KO 토글 버튼
- 모든 컴포넌트에 `en`/`ko` 카피 분기 적용
- Noto Sans KR 추가 (`next/font/google`), `word-break: keep-all` 적용

### 문서화
- `docs/decisions/003-stitch-brand-redesign.md`
- `docs/decisions/004-locale-switcher-cookie-based.md`
- `STATUS.md` 업데이트

## Test plan

- [ ] 라이트 모드에서 전체 섹션 레이아웃 확인
- [ ] 다크 모드에서 전체 섹션 레이아웃 확인
- [ ] 헤더 `EN / KO` 토글 클릭 시 텍스트 전환 확인
- [ ] 새로고침 후 언어 설정 유지 확인 (쿠키)
- [ ] 모바일 뷰포트에서 레이아웃 깨짐 없는지 확인
- [ ] `pnpm build` 성공 확인

## Related

- Closes #4
- ORCH 에픽: projectmiluju/cast-canvas-lab-orchestrator#8
- FE 후속: projectmiluju/cast-canvas-lab-fe#22

Made with [Cursor](https://cursor.com)